### PR TITLE
Added index, create, update, show endpoints and updated UI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'jbuilder', '~> 2.5'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
+gem 'responders'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -51,6 +52,10 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+end
+
+group :test do
+  gem 'rails-controller-testing'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.1.4)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (0.1.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -134,6 +138,9 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    responders (2.4.0)
+      actionpack (>= 4.2.0, < 5.3)
+      railties (>= 4.2.0, < 5.3)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
     sass (3.5.3)
@@ -198,6 +205,8 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.7)
   rails (~> 5.1.4)
+  rails-controller-testing
+  responders
   sass-rails (~> 5.0)
   selenium-webdriver
   spring

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  def render_exception(resource)
+    render json: resource.errors, status: :unprocessable_entity
+  end
 end

--- a/app/controllers/desks_controller.rb
+++ b/app/controllers/desks_controller.rb
@@ -1,0 +1,41 @@
+class DesksController < ApplicationController
+  before_action :load_desk, only: %i(show update)
+
+  respond_to :html, only: %i(show)
+  respond_to :json, only: %i(show create update)
+
+  def index
+    @desks = Desk.all
+  end
+
+  def create
+    desk = Desk.new(desk_params)
+    if desk.save
+      respond_with(desk)
+    else
+      render_exception(desk)
+    end
+  end
+
+  def show
+    respond_with(@desk)
+  end
+
+  def update
+    if @desk.update(desk_params)
+      respond_with(@desk)
+    else
+      render_exception(@desk)
+    end
+  end
+
+  private
+
+  def load_desk
+    @desk = Desk.find(params[:id])
+  end
+
+  def desk_params
+    params.require(:desk).permit(:name, :occupied)
+  end
+end

--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -1,4 +1,0 @@
-class IndexController < ApplicationController
-  def index
-  end
-end

--- a/app/views/desks/index.html.erb
+++ b/app/views/desks/index.html.erb
@@ -1,0 +1,7 @@
+<h3>Desk list</h3>
+<% @desks.each do |desk| %>
+  <ul>
+    <li><%= link_to desk.name, desk_path(desk) %></li>
+    <li><%= desk.occupied %></li>
+  </ul>
+<% end %>

--- a/app/views/desks/show.html.erb
+++ b/app/views/desks/show.html.erb
@@ -1,0 +1,7 @@
+<%= link_to "Back to desk list", root_path %>
+<h3>Desk details</h3>
+<ul>
+  <li><%= @desk.id %></li>
+  <li><%= @desk.name %></li>
+  <li><%= @desk.occupied %></li>
+</ul>

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -1,1 +1,0 @@
-<h1>Welcome to the SmartLibrary project written by DEM</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
   </head>
 
   <body>
+    <h1>SMART LIBRARY</h1>
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root 'index#index'
+  root 'desks#index'
+
+  resources :desks
 end

--- a/test/controllers/desks_controller_test.rb
+++ b/test/controllers/desks_controller_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class DesksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @desk = desks(:desk1)
+  end
+
+  test "#index responds with all the desks" do
+    get desks_path
+
+    assert_response :success
+  end
+
+  test "#create responds with 200 if params are valid" do
+    post desks_path(format: :json), params: { desk: { name: 'test desk' } }
+
+    parsed_response = JSON.parse(response.body, symbolize_names: true)
+
+    assert_response :success
+    refute_nil parsed_response[:id]
+    assert_equal 'test desk', parsed_response[:name]
+  end
+
+  test "#create responds with 422 if name is null" do
+    post desks_path, params: { desk: { name: nil } }
+
+    assert_response :unprocessable_entity
+  end
+
+  test "#show responds with desk" do
+    get desk_path(@desk)
+
+    assert_response :success
+    assert_template 'show'
+  end
+
+  test "#show responds with desk in json format" do
+    get desk_path(@desk, format: :json)
+
+    assert_response :success
+    assert_equal @desk.to_json, response.body
+  end
+
+  test "#update updates desk and responds with updated desk" do
+    put desk_path(@desk, format: :json), params: { desk: { occupied: false } }
+
+    assert_response 204
+  end
+
+  test "#update responds with 422 if occupied is attribute is null" do
+    put desk_path(@desk, format: :json), params: { desk: { name: nil } }
+
+    assert_response :unprocessable_entity
+  end
+end


### PR DESCRIPTION
#### Problem
Currently, we don't any endpoints to serve requests to other services or users of our new data models.

#### Solution
Added `index`, `create`, `show`, `update` actions for our `Desk` model.

Below you can see a breakdown of the endpoints available to the device:

- Show details of a desk with `id` of `1`:

_Request_
```ruby
GET "/desks/1.json"
```
_Response_
```
Status 200 OK

{
  "id": 1,
  "grouping_id": null,
  "name": "blah",
  "occupied": false,
  "created_at": "2017-11-05T23:46:06.755Z",
  "updated_at": "2017-11-05T23:46:06.755Z"
}
```
- Create a new desk

_Request_
```ruby
POST "/desks.json"

{
  "desk": {
    "name": "desk in 5th floor"
  }
}
```
_Response_
```
Status 201 Created

{
  "id": 12,
  "grouping_id": null,
  "name": "desk in 5th floor",
  "occupied": false,
  "created_at": "2017-11-10T04:02:53.035Z",
  "updated_at": "2017-11-10T04:02:53.035Z"
}
```

- Update an existing desk

_Request_
```ruby
PUT "/desks/12.json"

{
  "desk": {
    "occupied": true
  }
}
```
_Response_
```
Status: 204 No content
```

**Note**: All requests made from the device to our API must send `'application/json'` in the `Content-Type` header.

 - [x] Tested locally?