### PR TITLE
Added rack-cors to allow requests from anywhere

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,9 +33,9 @@ gem 'jbuilder', '~> 2.5'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 gem 'responders'
-
 gem 'jquery-rails'
 gem 'bootstrap-sass'
+gem 'rack-cors', :require => 'rack/cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
     public_suffix (3.0.0)
     puma (3.10.0)
     rack (2.0.3)
+    rack-cors (0.4.0)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rails (5.1.4)
@@ -215,6 +216,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 3.7)
+  rack-cors
   rails (~> 5.1.4)
   rails-controller-testing
   responders

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,7 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+
+    resource '*', headers: :any, methods: %i(get post put patch delete options head)
+  end
+end


### PR DESCRIPTION
#### Problem
We currently don't allow requests from other origins.

#### Solution
Add `rack-cors` to allow requests from anywhere so that the Pi can start using it. Resolves https://github.com/Smart-Library/smartlibrary/issues/6

 - [x] Tested locally?
