### PR TITLE
Added Procfile for Heroku to run migrations before deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: rake db:migrate


### PR DESCRIPTION
#### Problem
Migrations aren't running on every deploy.

#### Solution
Added `Procfile` for Heroku to run migrations.

Reference: 
http://mentalized.net/journal/2017/04/22/run-rails-migrations-on-heroku-deploy/

 - [ ] Tested locally?
