### PR TITLE
Dont protect from forgery for json requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :exception, unless: -> { request.format.json? }
 
   def render_exception(resource)
     render json: resource.errors, status: :unprocessable_entity


### PR DESCRIPTION
#### Problem
Currently running into `ActionController::InvalidAuthenticityToken` exceptions when making JSON requests to our production API.

#### Solution
Skip `protect_from_forgery` if the request is a JSON request, i.e a request made from the Pi.

 - [x] Tested locally?
