### PR TITLE
Use var instead of let since we're not using ES6

### DIFF
--- a/app/assets/javascripts/admin/edit/on_update_layout.js
+++ b/app/assets/javascripts/admin/edit/on_update_layout.js
@@ -10,12 +10,12 @@ function registerOnUpdateLayout() {
 }
 
 function serializeLayout() {
-  let layout = {};
+  var layout = {};
   $('.layout-area').children('.draggable').each(function(i) {
-    let type = $(this).attr('data-type');
+    var type = $(this).attr('data-type');
     layout[type] = layout[type] || {};
 
-    let id = $(this).attr('data-id');
+    var id = $(this).attr('data-id');
     layout[type][id] = {
       x: $(this).attr('data-x'),
       y: $(this).attr('data-y')


### PR DESCRIPTION
#### Problem
Currently running into `ExecJS::RuntimeError: SyntaxError: Unexpected token: name (layout)` because we're using `let` instead of `var`, which makes things go 💥  since we don't have ES6.

#### Solution
Replace `let` instances with `var`.

Tested with `RAILS_ENV=production rake assets:precompile --trace` and everything is 🍏 

 - [x] Tested locally?
