### PR TITLE
Enforce ruby 2.3.5 in gemfile for consistency across environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby "2.3.5"
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,5 +236,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
+RUBY VERSION
+   ruby 2.3.5p376
+
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
#### Problem
Our ruby versions are all over the place across environments, which makes it hard to develop.

#### Solution
Enforce it in the `Gemfile`, allowing `Heroku` and `CircleCI` to run the same ruby versions.

 - [x] Tested locally?
