### PR TITLE
broacast to socket in after_save callback instead of controllers

### DIFF
--- a/app/controllers/desks_controller.rb
+++ b/app/controllers/desks_controller.rb
@@ -23,7 +23,6 @@ class DesksController < ApplicationController
 
   def update
     if @desk.update(desk_params)
-      broadcast_desk_update if broadcast_needed?
       respond_with(@desk)
     else
       render_exception(@desk)
@@ -38,16 +37,5 @@ class DesksController < ApplicationController
 
   def desk_params
     params.require(:desk).permit(:name, :occupied)
-  end
-
-  def broadcast_needed?
-    !@desk.previous_changes.slice('name', 'occupied').empty?
-  end
-
-  def broadcast_desk_update
-    ActionCable.server.broadcast('desks',
-                                 desk_info: @desk.slice('id',
-                                                        'name',
-                                                        'occupied'))
   end
 end

--- a/app/models/desk.rb
+++ b/app/models/desk.rb
@@ -4,7 +4,15 @@ class Desk < ApplicationRecord
 
   validates :name, presence: true
 
+  after_save :broadcast_occupied, if: :saved_change_to_occupied?
+
   def type
     self.class.name.downcase
+  end
+
+  private
+
+  def broadcast_occupied
+    ActionCable.server.broadcast 'desks', desk_info: slice('id', 'occupied')
   end
 end

--- a/test/controllers/desks_controller_test.rb
+++ b/test/controllers/desks_controller_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class DesksControllerTest < ActionDispatch::IntegrationTest
-  include ActionCable::TestHelper
   include DeskHelper
 
   setup do
@@ -46,31 +45,21 @@ class DesksControllerTest < ActionDispatch::IntegrationTest
 
   test "#update updates desk and responds with updated desk" do
     occupied = @desk.occupied
-
     put desk_path(@desk, format: :json), params: { desk: { occupied: !occupied } }
 
-    @desk.reload
-
-    assert_equal !occupied, @desk.occupied
-
-
-    assert_broadcast_on('desks', desk_info: {id: @desk.id,
-                                             name: @desk.name,
-                                             occupied: @desk.occupied})
+    assert_equal !occupied, @desk.reload.occupied
     assert_response 204
   end
 
   test "#update doesn't broadcast when occupied attribute remains unchanged" do
     put desk_path(@desk, format: :json), params: { desk: { occupied: @desk.occupied } }
 
-    assert_no_broadcasts('desks')
     assert_response 204
   end
 
   test "#update responds with 422 if occupied is attribute is null" do
     put desk_path(@desk, format: :json), params: { desk: { name: nil } }
 
-    assert_no_broadcasts 'desk'
     assert_response :unprocessable_entity
   end
 end

--- a/test/models/desk_test.rb
+++ b/test/models/desk_test.rb
@@ -1,31 +1,52 @@
 require 'test_helper'
 
 class DeskTest < ActiveSupport::TestCase
-  def setup
+  include ActionCable::TestHelper
+
+  setup do
     @desk1 = desks :test_desk
   end
 
-  test 'valid' do
+  test "valid" do
     assert @desk1.valid?
   end
 
-  test 'valid without grouping' do
+  test "valid without grouping" do
     @desk1.grouping = nil
     assert_predicate @desk1, :valid?
   end
 
-  test 'invalid without name' do
+  test "invalid without name" do
     @desk1.name = nil
     refute_predicate @desk1, :valid?
     assert @desk1.errors.key? :name
   end
 
-  test 'occupied defaults to false' do
+  test "occupied defaults to false" do
     desk = Desk.new
     assert_equal(false, desk.occupied)
   end
 
-  test 'belongs to grouping1' do
+  test "belongs to grouping1" do
     assert_equal(groupings(:grouping1), @desk1.grouping)
+  end
+
+  test "broadcast when change to occupied" do
+    status = @desk1.occupied?
+    @desk1.update(occupied: !status)
+
+    assert_broadcast_on 'desks', desk_info: { id: @desk1.id, occupied: !status }
+  end
+
+  test "no broadcast when no change to occupied" do
+    @desk1.update(occupied: @desk1.occupied?)
+
+    assert_no_broadcasts 'desks'
+  end
+
+  test "no broadcast when change to name" do
+    @desk1.update(name: 'Random new name')
+
+    assert_no_broadcasts 'desks'
   end
 end


### PR DESCRIPTION
#### Problem
Broadcast on socket was performed in controller if save was successful. If desk was updated in some other way, broadcast wouldn't be sent. Furthermore, code for broadcasting after #create, #update, #destroy would  be repeated each time.

#### Solution
Broadcast on sockets in after_save callback. Thus, all paths that lead to a change in desk will automatically be broadcasted.

Also stopped broadcasting changes to name. Going down the road of updating config via sockets could get really complex. What if the grouping/desk hierarchy changes? I don't think those changes should be in the broadcast.

 - [X] Tested locally?
