### PR TITLE
created breadcrumb helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,14 @@
 module ApplicationHelper
+  def breadcrumb(area)
+    content_tag :nav, class: 'breadcrumb' do
+      hierarchy = area.hierarchy
+      hierarchy.each_with_index.collect do |e, i|
+        if i < hierarchy.size - 1
+          link_to e.name, e, class: 'breadcrumb-item'
+        else
+          content_tag :span, e.name, class: 'breadcrumb-item active'
+        end
+      end.reduce(&:+)
+    end
+  end
 end

--- a/app/models/desk.rb
+++ b/app/models/desk.rb
@@ -10,6 +10,14 @@ class Desk < ApplicationRecord
     self.class.name.downcase
   end
 
+  def hierarchy
+    if grouping
+      grouping.hierarchy << self
+    else
+      [self]
+    end
+  end
+
   private
 
   def broadcast_occupied

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -20,4 +20,12 @@ class Grouping < ApplicationRecord
   def occupied?
     children.all?(&:occupied?)
   end
+
+  def hierarchy
+    if parent_grouping
+      parent_grouping.hierarchy << self
+    else
+      [self]
+    end
+  end
 end

--- a/app/views/groupings/show.html.erb
+++ b/app/views/groupings/show.html.erb
@@ -1,6 +1,11 @@
 <div class="container">
   <div class="row">
     <div class="col-sm-12">
+      <%= breadcrumb(@grouping) %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-12">
       <h1><%= @grouping_name %></h1>
     </div>
   </div>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,4 +1,19 @@
 require 'test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
+  setup do
+    @grouping = groupings(:grouping2)
+  end
+
+  test "#breadcrumb returns nav element with class breadcrumb" do
+    assert_match /^<nav class="breadcrumb".*<\/nav>$/, breadcrumb(@grouping)
+  end
+
+  test "#breadcrumb displays leaf in span" do
+    assert_match /<span[^<>]*>#{@grouping.name}<\/span>/, breadcrumb(@grouping)
+  end
+
+  test "#breadcrumb displays parent in <a>" do
+    assert_match /<a[^<>]*>#{@grouping.parent_grouping.name}<\/a>/, breadcrumb(@grouping)
+  end
 end

--- a/test/models/desk_test.rb
+++ b/test/models/desk_test.rb
@@ -49,4 +49,8 @@ class DeskTest < ActiveSupport::TestCase
 
     assert_no_broadcasts 'desks'
   end
+
+  test "#hierarchy returns correct list" do
+    assert_equal [@desk1.grouping, @desk1], @desk1.hierarchy
+  end
 end

--- a/test/models/grouping_test.rb
+++ b/test/models/grouping_test.rb
@@ -6,41 +6,49 @@ class GroupingTest < ActiveSupport::TestCase
     @grouping2 = groupings :grouping2
   end
 
-  test 'valid without parent' do
+  test "valid without parent" do
     assert @grouping1.valid?
   end
 
-  test 'valid with parent' do
+  test "valid with parent" do
     assert @grouping2.valid?
   end
 
-  test 'invalid without name' do
+  test "invalid without name" do
     @grouping1.name = nil
     refute_predicate @grouping1, :valid?
     assert @grouping1.errors.messages.key? :name
   end
 
-  test 'grouping2 belongs to grouping1' do
+  test "grouping2 belongs to grouping1" do
     assert_equal(@grouping1, @grouping2.parent_grouping)
   end
 
-  test 'grouping1 has grouping2' do
+  test "grouping1 has grouping2" do
     assert_equal(@grouping2, @grouping1.child_groupings.first)
   end
 
-  test 'grouping1 has desk1' do
+  test "grouping1 has desk1" do
     assert_equal(desks(:test_desk), @grouping1.desks.first)
   end
 
-  test '#children returns array of desks and groupings inside the grouping' do
+  test "#children returns array of desks and groupings inside the grouping" do
     assert_equal @grouping1.desks + @grouping1.child_groupings, @grouping1.children
   end
 
-  test '#occupied? false' do
+  test "#occupied? false" do
     refute_predicate @grouping1, :occupied?
   end
 
-  test '#occupied? true' do
+  test "#occupied? true" do
     assert_predicate @grouping2, :occupied?
+  end
+
+  test "#hierarchy with parent" do
+    assert_equal [@grouping1, @grouping2], @grouping2.hierarchy
+  end
+
+  test "#hierarchy without parent" do
+    assert_equal [@grouping1], @grouping1.hierarchy
   end
 end


### PR DESCRIPTION
#### Problem
Navigation is tough for users who are down the rabbit whole of groupings.

#### Solution
Give the user breadcrumbs with links so they know where they are in the hierarchy and can navigate easily

 - [X] Tested locally?
